### PR TITLE
Revert localization of remind me later remove automaticallyUpdateEnabled

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -327,10 +327,9 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.laterButton.hidden = YES;
     }
 
-    if([self automaticallyUpdateEnabled]) {
+    if([self.host boolForInfoDictionaryKey:SUAutomaticallyUpdateKey]) {
         self.skipButton.hidden = YES;
         self.automaticallyInstallUpdatesButton.hidden = YES;
-        [self.laterButton setTitle:SULocalizedString(@"Install later", @"Alternate title for 'Remind me later' button when automatic updates are enabled")];
     }
 
     [self.window center];
@@ -338,16 +337,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (BOOL)automaticChecksEnabled {
     NSNumber *automaticChecksEnabled = [self.host objectForKey:SUEnableAutomaticChecksKey];
-    if (automaticChecksEnabled == nil)
-    {
-        return false;
-    }
-
-    return [automaticChecksEnabled boolValue];
-}
-
-- (BOOL)automaticallyUpdateEnabled {
-    NSNumber *automaticChecksEnabled = [self.host objectForKey:SUAutomaticallyUpdateKey];
     if (automaticChecksEnabled == nil)
     {
         return false;


### PR DESCRIPTION
Signed-off-by: Lorena Rangel <lorena.rangel@docker.com>

# Sparkle Pull Request

## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [ ] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Description

Please include a summary of the change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app

macOS version tested: [place version here]
